### PR TITLE
Fixes a bug in the rendering of the menu that shows no selection

### DIFF
--- a/src/main/scala/scalajsreact/template/components/TopNav.scala
+++ b/src/main/scala/scalajsreact/template/components/TopNav.scala
@@ -48,7 +48,7 @@ object TopNav {
       <.header(
         <.nav(
           <.ul(Style.navMenu,
-            P.menus.map(item => <.li(^.key := item.name, Style.menuItem(item.route == P.selectedPage), item.name, P.ctrl setOnClick item.route)))
+            P.menus.map(item => <.li(^.key := item.name, Style.menuItem(item.route.getClass == P.selectedPage.getClass), item.name, P.ctrl setOnClick item.route)))
         )
       )
     }


### PR DESCRIPTION
We want to show the 'Item' as selected for all #items/* and not only for #items/info.